### PR TITLE
upgraded erlang19 to v19.3.6.12 and build function updated

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,16 +1,23 @@
 pkg_name=erlang19
 pkg_origin=core
-pkg_version=19.3
+pkg_version=19.3.6.12
 pkg_description="A programming language for massively scalable soft real-time systems."
 pkg_upstream_url="http://www.erlang.org/"
 pkg_dirname=otp_src_${pkg_version}
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=http://www.erlang.org/download/otp_src_${pkg_version}.tar.gz
+pkg_source=https://api.github.com/repos/erlang/otp/tarball/refs/tags/OTP-${pkg_version}
 pkg_filename=otp_src_${pkg_version}.tar.gz
-pkg_shasum=fe4a00651db39b8542b04530a48d24b2f2e7e0b77cbe93d728c9f05325bdfe83
+pkg_shasum=887ecf324c7d165a6f9a0d9b134b5b7c026385c4941e4e064b2adc0f422c49ec
 pkg_deps=(core/glibc core/zlib core/ncurses core/openssl core/sed)
-pkg_build_deps=(core/coreutils core/gcc core/make core/openssl core/perl core/m4)
+pkg_build_deps=(core/coreutils
+	core/gcc
+       	core/make
+       	core/openssl
+       	core/perl
+       	core/m4
+	core/autoconf/2.69
+)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
@@ -26,20 +33,23 @@ do_prepare() {
     ln -sv "$(pkg_path_for coreutils)/bin/rm" /bin/rm
     _clean_rm=true
   fi
+	cp -r ${HAB_CACHE_SRC_PATH}/erlang-otp-0b88ef5/* ${HAB_CACHE_SRC_PATH}/${pkg_dirname}
 }
 
 do_build() {
-  ./configure --prefix="${pkg_prefix}" \
-              --enable-threads \
-              --enable-smp-support \
-              --enable-kernel-poll \
-              --enable-dynamic-ssl-lib \
-              --enable-shared-zlib \
-              --enable-hipe \
-              --with-ssl="$(pkg_path_for openssl)/lib" \
-              --with-ssl-include="$(pkg_path_for openssl)/include" \
-              --without-javac
-  make
+	./otp_build autoconf
+	./otp_build configure \
+		--prefix="${pkg_prefix}" \
+		--enable-threads \
+		--enable-smp-support \
+		--enable-kernel-poll \
+		--enable-dynamic-ssl-lib \
+		--enable-shared-zlib \
+		--enable-hipe \
+		--with-ssl="$(pkg_path_for openssl)" \
+		--with-ssl-include="$(pkg_path_for openssl)/include" \
+		--without-javac
+	make
 }
 
 do_end() {


### PR DESCRIPTION
1. upgraded erlang19 to v19.3.6.12
2. updated build function as per change in source tarball
3. using step down autoconf v2.69 due to incompatibility with autoconf v2.71

Signed-off-by: Nimit <nimit.jyotiana@hotmail.com>